### PR TITLE
Use setText when call setTrueText and setFalseText

### DIFF
--- a/statebutton/src/main/java/net/yuzumone/statebutton/StateButton.java
+++ b/statebutton/src/main/java/net/yuzumone/statebutton/StateButton.java
@@ -80,18 +80,22 @@ public class StateButton extends TextView {
 
     public void setTrueText(String trueText) {
         this.trueText = trueText;
+        if (isChecked) this.setText(trueText);
     }
 
     public void setTrueText(@StringRes int resId) {
         this.trueText = context.getString(resId);
+        if (isChecked) this.setText(trueText);
     }
 
     public void setFalseText(String falseText) {
         this.falseText = falseText;
+        if (!isChecked) this.setText(falseText);
     }
 
     public void setFalseText(@StringRes int resId) {
         this.falseText = context.getString(resId);
+        if (!isChecked) this.setText(falseText);
     }
 
     @Override


### PR DESCRIPTION
If you call setTrueText or setFalseText after setState, there is no text on the button